### PR TITLE
Fix du fichier non reconnaissable par debian

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Remets le comportement par défaut, au cas où les utilisateurs n'ont pas mis core.autocrlf.
+* text=auto

--- a/start-script.sh
+++ b/start-script.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 service mariadb start
+#a2enmod rewrite
+
 echo "<?php phpinfo(); ?>" > /var/www/html/info.php 
+
 mysql < /data/create_db.sql
+
+# Launch Apache
 /usr/sbin/apache2ctl -DFOREGROUND
+#service apache2 start


### PR DESCRIPTION
Cette PR fixe le problème #1 en rajoutant un `.gitattribute`, qui permet d'assurer que tous les nouveaux fichiers seront correctement formatés pour Unix, et remets les commentaires dans le `start-script.sh` afin de notifier GitHub du changement de format de fin de ligne. Cependant, je ne sais si cela sera suffisant. D'après [la documentation GitHub](https://docs.github.com/en/get-started/getting-started-with-git/configuring-git-to-handle-line-endings#refreshing-a-repository-after-changing-line-endings), il faudrait créer un commit qui supprime le script, puis refaire un commit rajoutant à nouveau le fichier pour que le format de fin de fichier soit correcte.